### PR TITLE
subscriptions for order_payment_id join sales_order_payment table

### DIFF
--- a/Model/Cron/Bill.php
+++ b/Model/Cron/Bill.php
@@ -99,13 +99,20 @@ class Bill
         $subscriptions = $this->collectionFactory->create();
         $connection = $this->resource->getConnection();
         $vaultPaymentToken = $connection->getTableName('vault_payment_token_order_payment_link');
+        $salesOrderPayment = $connection->getTableName('sales_order_payment');
         $currentDateEnd = $currentDate.' 23:59:59';
         $currentDate .= ' 00:00:00';
-        $subscriptions->getSelect()->join(
-            $vaultPaymentToken.' as pt',
-            'main_table.subscribe_order_id = pt.order_payment_id',
-            ['payment_token_id']
-        );
+        $subscriptions->getSelect()
+            ->join(
+                $salesOrderPayment.' as sop',
+                'main_table.subscribe_order_id = sop.parent_id',
+                ['entity_id']
+            )
+            ->join(
+                $vaultPaymentToken.' as pt',
+                'sop.entity_id = pt.order_payment_id',
+                ['payment_token_id']
+            );
         $subscriptions->addFieldToFilter('next_renewed', ['lteq' => $currentDateEnd])
             ->addFieldToFilter('next_renewed', ['gteq' => $currentDate])
             ->addFieldToFilter('status', ['eq' => 1])


### PR DESCRIPTION
Issue: payment_token_ids fetched were wrong due to wrong join condition (order_id in subscription with order_payment_id in vault_payment_token_order_payment_link).

Solution: Solved by joining sales_order_payment to get the order_payment_id which will be used to join with order_payment_id in vault_payment_token_order_payment_link.